### PR TITLE
Add login page

### DIFF
--- a/servers/nextjs/app/login/page.tsx
+++ b/servers/nextjs/app/login/page.tsx
@@ -1,0 +1,7 @@
+import LoginForm from "@/components/auth/LoginForm";
+
+const LoginPage = () => {
+  return <LoginForm />;
+};
+
+export default LoginPage;

--- a/servers/nextjs/components/auth/LoginForm.tsx
+++ b/servers/nextjs/components/auth/LoginForm.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useState, FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { useDispatch } from "react-redux";
+import { login } from "@/store/slices/auth";
+
+const LoginForm = () => {
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (username && password) {
+      dispatch(login({ user: username }));
+      router.push("/");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col max-w-sm mx-auto mt-10 gap-4">
+      <input
+        type="text"
+        placeholder="Username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        className="border rounded p-2"
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="border rounded p-2"
+      />
+      <button type="submit" className="bg-blue-500 text-white rounded p-2">
+        Login
+      </button>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/servers/nextjs/store/slices/auth.ts
+++ b/servers/nextjs/store/slices/auth.ts
@@ -1,0 +1,28 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface AuthState {
+  isLoggedIn: boolean;
+  user?: string;
+}
+
+const initialState: AuthState = {
+  isLoggedIn: false,
+};
+
+const authSlice = createSlice({
+  name: "auth",
+  initialState,
+  reducers: {
+    login: (state, action: PayloadAction<{ user: string }>) => {
+      state.isLoggedIn = true;
+      state.user = action.payload.user;
+    },
+    logout: (state) => {
+      state.isLoggedIn = false;
+      state.user = undefined;
+    },
+  },
+});
+
+export const { login, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/servers/nextjs/store/store.ts
+++ b/servers/nextjs/store/store.ts
@@ -4,12 +4,14 @@ import presentationGenerationReducer from "./slices/presentationGeneration";
 import themeReducer from "@/app/(presentation-generator)/store/themeSlice";
 import pptGenUploadReducer from "./slices/presentationGenUpload";
 import userConfigReducer from "./slices/userConfig";
+import authReducer from "./slices/auth";
 export const store = configureStore({
   reducer: {
     presentationGeneration: presentationGenerationReducer,
     theme: themeReducer,
     pptGenUpload: pptGenUploadReducer,
     userConfig: userConfigReducer,
+    auth: authReducer,
   },
 });
 


### PR DESCRIPTION
## Summary
- add login form component
- add auth Redux slice and wire up store
- create login page

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688649f4db6c832da5096353a1ec43f9