### PR TITLE
Enforce login across site

### DIFF
--- a/servers/nextjs/README.md
+++ b/servers/nextjs/README.md
@@ -34,3 +34,10 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Default Login
+
+The app restricts access to a single user. Use the credentials below when signing in:
+
+- **Username:** `admin@clingroup.net`
+- **Password:** `clingroup#123@`

--- a/servers/nextjs/app/(presentation-generator)/components/UserAccount.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/UserAccount.tsx
@@ -1,13 +1,22 @@
 "use client";
-import { LayoutDashboard, Settings } from "lucide-react";
+import { LayoutDashboard, Settings, LogOut } from "lucide-react";
 import React from "react";
 import Link from "next/link";
 import { RootState } from "@/store/store";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
+import { logout } from "@/store/slices/auth";
+import { useRouter } from "next/navigation";
 
 const UserAccount = () => {
 
   const canChangeKeys = useSelector((state: RootState) => state.userConfig.can_change_keys);
+  const dispatch = useDispatch();
+  const router = useRouter();
+
+  const handleLogout = () => {
+    dispatch(logout());
+    router.push('/login');
+  };
 
   return (
     <div className="flex items-center gap-2">
@@ -35,6 +44,13 @@ const UserAccount = () => {
           </span>
         </Link>
       )}
+      <button
+        onClick={handleLogout}
+        className="flex items-center gap-2 px-3 py-2 text-white hover:bg-primary/80 rounded-md transition-colors outline-none"
+      >
+        <LogOut className="w-5 h-5" />
+        <span className="text-sm font-medium font-inter">Logout</span>
+      </button>
     </div>
   );
 };

--- a/servers/nextjs/app/storeInitializer.tsx
+++ b/servers/nextjs/app/storeInitializer.tsx
@@ -5,7 +5,8 @@ import { setCanChangeKeys, setLLMConfig } from '@/store/slices/userConfig';
 import { Loader2 } from 'lucide-react';
 import { hasValidLLMConfig } from '@/utils/storeHelpers';
 import { usePathname, useRouter } from 'next/navigation';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@/store/store';
 
 export function StoreInitializer({ children }: { children: React.ReactNode }) {
   const dispatch = useDispatch();
@@ -13,11 +14,28 @@ export function StoreInitializer({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const router = useRouter();
   const route = usePathname();
+  const isLoggedIn = useSelector((state: RootState) => state.auth.isLoggedIn);
 
-  // Fetch user config state
+  // Redirect unauthenticated users to login
   useEffect(() => {
+    if (!isLoggedIn) {
+      if (route !== '/login') {
+        router.push('/login');
+        setLoadingToFalseAfterNavigatingTo('/login');
+      } else {
+        setIsLoading(false);
+      }
+      return;
+    }
+
+    if (route === '/login') {
+      router.push('/');
+      setLoadingToFalseAfterNavigatingTo('/');
+      return;
+    }
+
     fetchUserConfigState();
-  }, []);
+  }, [isLoggedIn, route]);
 
   const setLoadingToFalseAfterNavigatingTo = (pathname: string) => {
     const interval = setInterval(() => {

--- a/servers/nextjs/components/auth/LoginForm.tsx
+++ b/servers/nextjs/components/auth/LoginForm.tsx
@@ -9,12 +9,18 @@ const LoginForm = () => {
   const router = useRouter();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    if (username && password) {
+    if (
+      username === "admin@clingroup.net" &&
+      password === "clingroup#123@"
+    ) {
       dispatch(login({ user: username }));
       router.push("/");
+    } else {
+      setError("Invalid credentials");
     }
   };
 
@@ -37,6 +43,7 @@ const LoginForm = () => {
       <button type="submit" className="bg-blue-500 text-white rounded p-2">
         Login
       </button>
+      {error && <p className="text-red-500">{error}</p>}
     </form>
   );
 };


### PR DESCRIPTION
## Summary
- redirect unauthenticated users to the login page in StoreInitializer
- add hard-coded credential check in LoginForm
- document default credentials
- add logout option in the UserAccount menu

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68864fb0a134832dbcf782ed57d82a58