### PR TITLE
Add web-based social posting feature

### DIFF
--- a/servers/fastapi/api/main.py
+++ b/servers/fastapi/api/main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 
 from api.models import SelectedLLMProvider
 from api.routers.presentation.router import presentation_router
+from api.routers.social.router import social_router
 from api.services.database import sql_engine
 from api.utils.supported_ollama_models import SUPPORTED_OLLAMA_MODELS
 from api.utils.utils import update_env_with_user_config
@@ -96,3 +97,4 @@ async def update_env_middleware(request: Request, call_next):
 
 
 app.include_router(presentation_router)
+app.include_router(social_router)

--- a/servers/fastapi/api/routers/social/router.py
+++ b/servers/fastapi/api/routers/social/router.py
@@ -1,0 +1,76 @@
+import json
+import os
+from typing import List, Optional
+
+import requests
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+
+from openai import AsyncOpenAI
+
+social_router = APIRouter(prefix="/api/v1/social")
+
+OPENAI_MODEL = os.getenv("OPENAI_CHAT_MODEL", "gpt-4o")
+IMAGE_MODEL = os.getenv("OPENAI_IMAGE_MODEL", "dall-e-3")
+FACEBOOK_GRAPH_VERSION = os.getenv("FACEBOOK_GRAPH_VERSION", "v19.0")
+FACEBOOK_TOKEN = os.getenv("FACEBOOK_TOKEN")
+
+
+async def _transcribe_audio(file: UploadFile, client: AsyncOpenAI) -> str:
+    data = await file.read()
+    return await client.audio.transcriptions.create(model="whisper-1", file=data, response_format="text")
+
+
+async def _generate_content(text: str, client: AsyncOpenAI) -> dict:
+    system = "You are an AI social media content creator. Your task is to create engaging and SEO-optimized social media content (200-500 characters) and generate a detailed image prompt. Return a JSON object with keys 'content' and 'image_prompt'."
+    resp = await client.chat.completions.create(
+        model=OPENAI_MODEL,
+        messages=[{"role": "system", "content": system}, {"role": "user", "content": text}],
+    )
+    content = resp.choices[0].message.content
+    try:
+        return json.loads(content)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Failed to parse LLM response") from e
+
+
+async def _generate_image(prompt: str, client: AsyncOpenAI) -> str:
+    resp = await client.images.generate(model=IMAGE_MODEL, prompt=prompt, n=1, size="1024x1024")
+    return resp.data[0].url
+
+
+def _get_pages():
+    if not FACEBOOK_TOKEN:
+        return []
+    url = f"https://graph.facebook.com/{FACEBOOK_GRAPH_VERSION}/me/accounts"
+    resp = requests.get(url, params={"access_token": FACEBOOK_TOKEN})
+    if resp.status_code != 200:
+        raise HTTPException(status_code=500, detail="Failed to fetch Facebook pages")
+    data = resp.json().get("data", [])
+    return [{"id": p["id"], "name": p["name"], "access_token": p.get("access_token")} for p in data]
+
+
+@social_router.post("/generate")
+async def generate(text: Optional[str] = Form(None), file: Optional[UploadFile] = File(None)):
+    if not text and not file:
+        raise HTTPException(status_code=400, detail="Provide text or audio")
+    client = AsyncOpenAI()
+    if file:
+        text = await _transcribe_audio(file, client)
+    data = await _generate_content(text, client)
+    image_url = await _generate_image(data["image_prompt"], client)
+    pages = _get_pages()
+    return {"content": data["content"], "image_url": image_url, "pages": pages}
+
+
+@social_router.post("/publish")
+async def publish(page_ids: List[str], caption: str = Form(...), image_url: str = Form(...)):
+    if not FACEBOOK_TOKEN:
+        raise HTTPException(status_code=400, detail="FACEBOOK_TOKEN not set")
+    results = []
+    for pid in page_ids:
+        resp = requests.post(
+            f"https://graph.facebook.com/{FACEBOOK_GRAPH_VERSION}/{pid}/photos",
+            data={"url": image_url, "message": caption, "access_token": FACEBOOK_TOKEN},
+        )
+        results.append({"page_id": pid, "status": resp.status_code})
+    return {"results": results}

--- a/servers/nextjs/app/social/page.tsx
+++ b/servers/nextjs/app/social/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { useState } from "react";
+
+interface PageInfo { id: string; name: string }
+
+export default function SocialPage() {
+  const [text, setText] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [content, setContent] = useState<string | null>(null);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [pages, setPages] = useState<PageInfo[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const generate = async () => {
+    const form = new FormData();
+    if (text) form.append("text", text);
+    if (file) form.append("file", file);
+    const res = await fetch("/api/v1/social/generate", { method: "POST", body: form });
+    if (res.ok) {
+      const data = await res.json();
+      setContent(data.content);
+      setImageUrl(data.image_url);
+      setPages(data.pages || []);
+    }
+  };
+
+  const publish = async () => {
+    if (!content || !imageUrl) return;
+    const res = await fetch("/api/v1/social/publish", {
+      method: "POST",
+      body: new URLSearchParams({ caption: content, image_url: imageUrl, page_ids: selected.join() }),
+    });
+    if (res.ok) alert("Published");
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Social Post Generator</h1>
+      <textarea className="w-full border p-2" placeholder="Enter text" value={text} onChange={e => setText(e.target.value)} />
+      <input type="file" accept="audio/*" onChange={e => setFile(e.target.files?.[0] || null)} />
+      <button className="bg-blue-600 text-white px-4 py-2" onClick={generate}>Generate</button>
+      {content && (
+        <div className="space-y-2">
+          <p>{content}</p>
+          {imageUrl && <img src={imageUrl} alt="generated" className="max-w-sm" />}
+          {pages.length > 0 && (
+            <select multiple value={selected} onChange={e => setSelected(Array.from(e.target.selectedOptions).map(o => o.value))} className="border p-2 w-full">
+              {pages.map(p => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          )}
+          {pages.length > 0 && <button className="bg-green-600 text-white px-4 py-2" onClick={publish}>Publish</button>}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create social router in FastAPI to generate social posts and publish to Facebook
- expose router from main FastAPI app
- add simple Next.js page for creating and publishing posts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*
- `npm run lint` *(interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68865e72c160832db211f260ccf0d701