### PR TITLE
Add manual social post option

### DIFF
--- a/servers/nextjs/app/social/page.tsx
+++ b/servers/nextjs/app/social/page.tsx
@@ -1,20 +1,46 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import Header from "@/app/dashboard/components/Header";
+import Wrapper from "@/components/Wrapper";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
 
 interface PageInfo { id: string; name: string }
 
 export default function SocialPage() {
   const [text, setText] = useState("");
-  const [file, setFile] = useState<File | null>(null);
+  const [audio, setAudio] = useState<File | null>(null);
   const [content, setContent] = useState<string | null>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [pages, setPages] = useState<PageInfo[]>([]);
   const [selected, setSelected] = useState<string[]>([]);
 
+  const [manualCaption, setManualCaption] = useState("");
+  const [manualFile, setManualFile] = useState<File | null>(null);
+  const [manualPreview, setManualPreview] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPages = async () => {
+      const res = await fetch("/api/v1/social/pages");
+      if (res.ok) {
+        const data = await res.json();
+        setPages(data.pages || []);
+      }
+    };
+    fetchPages();
+  }, []);
+
   const generate = async () => {
     const form = new FormData();
     if (text) form.append("text", text);
-    if (file) form.append("file", file);
+    if (audio) form.append("file", audio);
     const res = await fetch("/api/v1/social/generate", { method: "POST", body: form });
     if (res.ok) {
       const data = await res.json();
@@ -24,35 +50,94 @@ export default function SocialPage() {
     }
   };
 
-  const publish = async () => {
+  const publishAI = async () => {
     if (!content || !imageUrl) return;
-    const res = await fetch("/api/v1/social/publish", {
-      method: "POST",
-      body: new URLSearchParams({ caption: content, image_url: imageUrl, page_ids: selected.join() }),
-    });
+    const body = new FormData();
+    body.append("caption", content);
+    body.append("image_url", imageUrl);
+    selected.forEach((id) => body.append("page_ids", id));
+    const res = await fetch("/api/v1/social/publish", { method: "POST", body });
     if (res.ok) alert("Published");
   };
 
+  const publishManual = async () => {
+    if (!manualCaption || !manualFile) return;
+    const body = new FormData();
+    body.append("caption", manualCaption);
+    body.append("file", manualFile);
+    selected.forEach((id) => body.append("page_ids", id));
+    const res = await fetch("/api/v1/social/publish", { method: "POST", body });
+    if (res.ok) alert("Published");
+  };
+
+  const onManualFileChange = (file: File | null) => {
+    setManualFile(file);
+    if (file) {
+      setManualPreview(URL.createObjectURL(file));
+    } else {
+      setManualPreview(null);
+    }
+  };
+
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-xl font-bold">Social Post Generator</h1>
-      <textarea className="w-full border p-2" placeholder="Enter text" value={text} onChange={e => setText(e.target.value)} />
-      <input type="file" accept="audio/*" onChange={e => setFile(e.target.files?.[0] || null)} />
-      <button className="bg-blue-600 text-white px-4 py-2" onClick={generate}>Generate</button>
-      {content && (
-        <div className="space-y-2">
-          <p>{content}</p>
-          {imageUrl && <img src={imageUrl} alt="generated" className="max-w-sm" />}
+    <div className="min-h-screen bg-[#E9E8F8]">
+      <Header />
+      <Wrapper className="py-10 max-w-2xl">
+        <Tabs defaultValue="ai" className="w-full space-y-6">
+          <TabsList className="w-full flex justify-center mb-4">
+            <TabsTrigger value="ai">AI Generator</TabsTrigger>
+            <TabsTrigger value="manual">Manual</TabsTrigger>
+          </TabsList>
+          <TabsContent value="ai" className="space-y-4">
+            <Textarea
+              placeholder="Enter text"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+            />
+            <Input type="file" accept="audio/*" onChange={(e) => setAudio(e.target.files?.[0] || null)} />
+            <Button onClick={generate}>Generate</Button>
+            {content && (
+              <div className="space-y-2">
+                <p>{content}</p>
+                {imageUrl && <img src={imageUrl} alt="generated" className="max-w-sm" />}
+              </div>
+            )}
+          </TabsContent>
+          <TabsContent value="manual" className="space-y-4">
+            <Textarea
+              placeholder="Caption"
+              value={manualCaption}
+              onChange={(e) => setManualCaption(e.target.value)}
+            />
+            <Input type="file" accept="image/*" onChange={(e) => onManualFileChange(e.target.files?.[0] || null)} />
+            {manualPreview && <img src={manualPreview} alt="preview" className="max-w-sm" />}
+          </TabsContent>
           {pages.length > 0 && (
-            <select multiple value={selected} onChange={e => setSelected(Array.from(e.target.selectedOptions).map(o => o.value))} className="border p-2 w-full">
-              {pages.map(p => (
-                <option key={p.id} value={p.id}>{p.name}</option>
+            <select
+              multiple
+              value={selected}
+              onChange={(e) =>
+                setSelected(Array.from(e.target.selectedOptions).map((o) => o.value))
+              }
+              className="border p-2 w-full"
+            >
+              {pages.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
               ))}
             </select>
           )}
-          {pages.length > 0 && <button className="bg-green-600 text-white px-4 py-2" onClick={publish}>Publish</button>}
-        </div>
-      )}
+          {selected.length > 0 && (
+            <div className="flex gap-4">
+              <Button onClick={publishAI}>Publish AI Post</Button>
+              <Button onClick={publishManual} variant="secondary">
+                Publish Manual Post
+              </Button>
+            </div>
+          )}
+        </Tabs>
+      </Wrapper>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- make social page responsive and match site style
- add manual image & caption posting
- extend API with `/pages` endpoint and upload support

## Testing
- `npm run lint` *(fails: requires interactive configuration)*
- `pytest` *(fails: missing modules `uvicorn`, `fastapi`)*

------
https://chatgpt.com/codex/tasks/task_e_68866d4496dc832da82467d75d0dcc8b