### PR TITLE
Implement admin user management and flyer enhancements

### DIFF
--- a/servers/nextjs/app/(presentation-generator)/components/UserAccount.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/UserAccount.tsx
@@ -25,6 +25,8 @@ const UserAccount = () => {
     router.push("/login");
   };
 
+  const user = useSelector((state: RootState) => state.auth.user);
+
   return (
     <div className="flex items-center gap-2">
       <Link
@@ -54,6 +56,17 @@ const UserAccount = () => {
         <ImageIcon className="w-5 h-5" />
         <span className="text-sm font-medium font-inter">Flyer</span>
       </Link>
+      {user === "admin@clingroup.net" && (
+        <Link
+          href="/admin"
+          prefetch={false}
+          className="flex items-center gap-2 px-3 py-2 text-white hover:bg-primary/80 rounded-md transition-colors outline-none"
+          role="menuitem"
+        >
+          <LayoutDashboard className="w-5 h-5" />
+          <span className="text-sm font-medium font-inter">Admin</span>
+        </Link>
+      )}
       {canChangeKeys && (
         <Link
           href="/settings"

--- a/servers/nextjs/app/admin/page.tsx
+++ b/servers/nextjs/app/admin/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { useState, useEffect } from "react";
+import Header from "@/app/dashboard/components/Header";
+import Wrapper from "@/components/Wrapper";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import ReactSelect from "react-select";
+
+interface PageInfo {
+  id: string;
+  name: string;
+}
+
+const AdminPage = () => {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [pages, setPages] = useState<PageInfo[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    const fetchPages = async () => {
+      const res = await fetch("/api/v1/social/pages");
+      if (res.ok) {
+        const data = await res.json();
+        setPages(data.pages || []);
+      }
+    };
+    fetchPages();
+  }, []);
+
+  const createUser = async () => {
+    const res = await fetch("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password, pages: selected }),
+    });
+    if (res.ok) {
+      setMessage("User created");
+      setUsername("");
+      setPassword("");
+      setSelected([]);
+    } else {
+      const data = await res.json();
+      setMessage(data.error || "Failed");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#E9E8F8]">
+      <Header />
+      <Wrapper className="py-10 max-w-xl space-y-4">
+        <h2 className="text-xl font-medium">Create User</h2>
+        <Input
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {pages.length > 0 && (
+          <ReactSelect
+            isMulti
+            className="basic-multi-select"
+            classNamePrefix="select"
+            options={pages.map((p) => ({ value: p.id, label: p.name }))}
+            value={pages
+              .filter((p) => selected.includes(p.id))
+              .map((p) => ({ value: p.id, label: p.name }))}
+            onChange={(opts) => setSelected(opts.map((o) => o.value as string))}
+          />
+        )}
+        <Button onClick={createUser}>Create User</Button>
+        {message && <p>{message}</p>}
+      </Wrapper>
+    </div>
+  );
+};
+
+export default AdminPage;

--- a/servers/nextjs/app/api/auth/route.ts
+++ b/servers/nextjs/app/api/auth/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { settingsStore } from '@/app/(presentation-generator)/services/setting-store';
+import crypto from 'crypto';
+
+const USERS_KEY = 'users';
+
+function loadUsers() {
+  return settingsStore.get(USERS_KEY, []);
+}
+
+function hashPassword(password: string) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+export async function POST(request: NextRequest) {
+  const { username, password } = await request.json();
+  const users = loadUsers();
+  const hashed = hashPassword(password);
+  const user = users.find((u: any) => u.username === username && u.password === hashed);
+  if (!user) {
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+  }
+  return NextResponse.json({ username: user.username, pages: user.pages || [] });
+}

--- a/servers/nextjs/app/api/users/route.ts
+++ b/servers/nextjs/app/api/users/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { settingsStore } from '@/app/(presentation-generator)/services/setting-store';
+import crypto from 'crypto';
+
+const USERS_KEY = 'users';
+
+function loadUsers() {
+  return settingsStore.get(USERS_KEY, []);
+}
+
+function saveUsers(users: any[]) {
+  settingsStore.set(USERS_KEY, users);
+}
+
+function hashPassword(password: string) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+export async function GET() {
+  const users = loadUsers().map((u: any) => ({ username: u.username, pages: u.pages || [] }));
+  return NextResponse.json({ users });
+}
+
+export async function POST(request: NextRequest) {
+  const { username, password, pages } = await request.json();
+  if (!username || !password) {
+    return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
+  }
+  const users = loadUsers();
+  if (users.some((u: any) => u.username === username)) {
+    return NextResponse.json({ error: 'User exists' }, { status: 400 });
+  }
+  users.push({ username, password: hashPassword(password), pages: pages || [] });
+  saveUsers(users);
+  return NextResponse.json({ success: true });
+}

--- a/servers/nextjs/app/flyer/page.tsx
+++ b/servers/nextjs/app/flyer/page.tsx
@@ -5,6 +5,8 @@ import Wrapper from "@/components/Wrapper";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import ReactSelect from "react-select";
 
 export default function FlyerPage() {
   interface Step {
@@ -17,6 +19,11 @@ export default function FlyerPage() {
   const [topic, setTopic] = useState("");
   const [steps, setSteps] = useState<Step[]>([]);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [design, setDesign] = useState("cartoon");
+
+  const [manualCaption, setManualCaption] = useState("");
+  const [manualFile, setManualFile] = useState<File | null>(null);
+  const [manualPreview, setManualPreview] = useState<string | null>(null);
 
   const addStep = () => {
     setSteps([...steps, { title: "", text: "" }]);
@@ -35,16 +42,26 @@ export default function FlyerPage() {
   };
 
   const buildPrompt = () => {
-    return `Create an infographic flyer in a modern, colorful cartoon style with bold black outlines and soft pastel colors (light blue, yellow, pink).
+    const base = `Create an infographic flyer in a modern, colorful cartoon style with bold black outlines and soft pastel colors (light blue, yellow, pink).`;
+    const minimalist = `Create a clean minimalist infographic flyer with lots of white space and thin sans-serif fonts.`;
+    const retro = `Create a bold retro style infographic flyer with bright contrasting colors and thick outlines.`;
+
+    const styleMap: Record<string, string> = {
+      cartoon: base,
+      minimalist: minimalist,
+      retro: retro,
+    };
+
+    return `${styleMap[design]}
 The infographic should be titled "${title}" inside a large yellow thought bubble at the top, next to cartoon-style icons.
 
 Divide the flyer into ${steps.length} numbered sections. Each section should include:
-- A large number in a colored circle
-- A title (from user input)
-- A short description (from user input)
+1. A large, colored number inside a circle.
+2. A title for the section.
+3. A short description for each point.
 
 Topic: ${topic}
-Make the layout vertical, readable, and visually engaging.`;
+Make the layout vertical, highly visual, readable, and engaging for social media or print.`;
   };
 
   const generate = async () => {
@@ -61,57 +78,97 @@ Make the layout vertical, readable, and visually engaging.`;
     }
   };
 
+  const onManualFileChange = (file: File | null) => {
+    setManualFile(file);
+    if (file) {
+      setManualPreview(URL.createObjectURL(file));
+    } else {
+      setManualPreview(null);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-[#E9E8F8]">
       <Header />
       <Wrapper className="py-10 max-w-3xl space-y-4">
-        <div className="bg-white rounded p-4 space-y-4">
-          <Input
-            placeholder="Flyer title"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-          />
-          <Input
-            placeholder="General topic"
-            value={topic}
-            onChange={(e) => setTopic(e.target.value)}
-          />
-          <Textarea
-            placeholder="Flyer description"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-          />
-          {steps.map((step, idx) => (
-            <div key={idx} className="space-y-2 border-t pt-4">
-              <Input
-                placeholder={`Step ${idx + 1} Title`}
-                value={step.title}
-                onChange={(e) => updateStep(idx, "title", e.target.value)}
-              />
-              <Textarea
-                placeholder="Step description"
-                value={step.text}
-                onChange={(e) => updateStep(idx, "text", e.target.value)}
-              />
-              <Button
-                type="button"
-                variant="destructive"
-                onClick={() => removeStep(idx)}
-              >
-                Remove Step
-              </Button>
-            </div>
-          ))}
-          <Button type="button" variant="secondary" onClick={addStep}>
-            Add Step
-          </Button>
-          <Button onClick={generate}>Generate Flyer</Button>
-        </div>
-        {imageUrl && (
-          <div className="flex justify-center">
-            <img src={imageUrl} alt="flyer" className="max-w-sm w-full" />
-          </div>
-        )}
+        <Tabs defaultValue="ai" className="w-full space-y-6">
+          <TabsList className="w-full flex justify-center mb-4">
+            <TabsTrigger value="ai">AI Generator</TabsTrigger>
+            <TabsTrigger value="manual">Manual</TabsTrigger>
+          </TabsList>
+          <TabsContent value="ai" className="space-y-4 bg-white rounded p-4">
+            <ReactSelect
+              classNamePrefix="select"
+              options={[
+                { value: "cartoon", label: "Cartoon" },
+                { value: "minimalist", label: "Minimalist" },
+                { value: "retro", label: "Retro" },
+              ]}
+              value={{ value: design, label: design.charAt(0).toUpperCase() + design.slice(1) }}
+              onChange={(opt) => setDesign(opt!.value)}
+            />
+            <Input
+              placeholder="Flyer title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <Input
+              placeholder="General topic"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+            />
+            <Textarea
+              placeholder="Flyer description"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+            />
+            {steps.map((step, idx) => (
+              <div key={idx} className="space-y-2 border-t pt-4">
+                <Input
+                  placeholder={`Step ${idx + 1} Title`}
+                  value={step.title}
+                  onChange={(e) => updateStep(idx, "title", e.target.value)}
+                />
+                <Textarea
+                  placeholder="Step description"
+                  value={step.text}
+                  onChange={(e) => updateStep(idx, "text", e.target.value)}
+                />
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => removeStep(idx)}
+                >
+                  Remove Step
+                </Button>
+              </div>
+            ))}
+            <Button type="button" variant="secondary" onClick={addStep}>
+              Add Step
+            </Button>
+            <Button onClick={generate}>Generate Flyer</Button>
+            {imageUrl && (
+              <div className="flex justify-center pt-4">
+                <img src={imageUrl} alt="flyer" className="max-w-sm w-full" />
+              </div>
+            )}
+          </TabsContent>
+          <TabsContent value="manual" className="space-y-4 bg-white rounded p-4">
+            <Textarea
+              placeholder="Caption"
+              value={manualCaption}
+              onChange={(e) => setManualCaption(e.target.value)}
+            />
+            <Input
+              type="file"
+              accept="image/*"
+              onChange={(e) => onManualFileChange(e.target.files?.[0] || null)}
+            />
+            {manualPreview && (
+              <img src={manualPreview} alt="preview" className="max-w-sm" />
+            )}
+          </TabsContent>
+        </Tabs>
       </Wrapper>
     </div>
   );

--- a/servers/nextjs/app/social/page.tsx
+++ b/servers/nextjs/app/social/page.tsx
@@ -7,6 +7,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import ReactSelect from "react-select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useSelector } from "react-redux";
+import { RootState } from "@/store/store";
 
 interface PageInfo {
   id: string;
@@ -20,6 +22,8 @@ export default function SocialPage() {
   const [pages, setPages] = useState<PageInfo[]>([]);
   const [selected, setSelected] = useState<string[]>([]);
 
+  const allowedPages = useSelector((state: RootState) => state.auth.pages);
+
   const [manualCaption, setManualCaption] = useState("");
   const [manualFile, setManualFile] = useState<File | null>(null);
   const [manualPreview, setManualPreview] = useState<string | null>(null);
@@ -29,11 +33,15 @@ export default function SocialPage() {
       const res = await fetch("/api/v1/social/pages");
       if (res.ok) {
         const data = await res.json();
-        setPages(data.pages || []);
+        let fetched = data.pages || [];
+        if (allowedPages.length > 0) {
+          fetched = fetched.filter((p: PageInfo) => allowedPages.includes(p.id));
+        }
+        setPages(fetched);
       }
     };
     fetchPages();
-  }, []);
+  }, [allowedPages]);
 
   const generate = async () => {
     const form = new FormData();
@@ -46,7 +54,11 @@ export default function SocialPage() {
       const data = await res.json();
       setCaption(data.content);
       setImageUrl(data.image_url);
-      setPages(data.pages || []);
+      let fetched = data.pages || [];
+      if (allowedPages.length > 0) {
+        fetched = fetched.filter((p: PageInfo) => allowedPages.includes(p.id));
+      }
+      setPages(fetched);
     }
   };
 

--- a/servers/nextjs/components/auth/LoginForm.tsx
+++ b/servers/nextjs/components/auth/LoginForm.tsx
@@ -11,13 +11,17 @@ const LoginForm = () => {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (
-      username === "admin@clingroup.net" &&
-      password === "clingroup#123@"
-    ) {
-      dispatch(login({ user: username }));
+    setError("");
+    const res = await fetch("/api/auth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      dispatch(login({ user: data.username, pages: data.pages }));
       router.push("/");
     } else {
       setError("Invalid credentials");

--- a/servers/nextjs/store/slices/auth.ts
+++ b/servers/nextjs/store/slices/auth.ts
@@ -3,23 +3,27 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 interface AuthState {
   isLoggedIn: boolean;
   user?: string;
+  pages: string[];
 }
 
 const initialState: AuthState = {
   isLoggedIn: false,
+  pages: [],
 };
 
 const authSlice = createSlice({
   name: "auth",
   initialState,
   reducers: {
-    login: (state, action: PayloadAction<{ user: string }>) => {
+    login: (state, action: PayloadAction<{ user: string; pages: string[] }>) => {
       state.isLoggedIn = true;
       state.user = action.payload.user;
+      state.pages = action.payload.pages;
     },
     logout: (state) => {
       state.isLoggedIn = false;
       state.user = undefined;
+      state.pages = [];
     },
   },
 });


### PR DESCRIPTION
## Summary
- add basic user management APIs and admin page
- allow login through new auth endpoint and store page permissions
- filter Facebook pages based on logged in user's permissions
- enhance flyer page with design choices and manual mode

## Testing
- `npx next lint` *(fails: Error: canceled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_6886a067cd5c832d875a391315d8e819