### PR TITLE
Improve flyer prompt and save generated posts

### DIFF
--- a/servers/fastapi/api/sql_models.py
+++ b/servers/fastapi/api/sql_models.py
@@ -58,3 +58,21 @@ class KeyValueSqlModel(SQLModel, table=True):
 class PreferencesSqlModel(SQLModel, table=True):
     id: int = Field(default=0, primary_key=True)
     theme: Optional[dict] = Field(sa_column=Column(JSON, nullable=True), default=None)
+
+
+class SocialPostSqlModel(SQLModel, table=True):
+    id: str = Field(default_factory=get_random_uuid, primary_key=True)
+    created_at: datetime = Field(default=datetime.now())
+    caption: str
+    image_url: Optional[str] = None
+    file: Optional[str] = None
+
+class FlyerSqlModel(SQLModel, table=True):
+    id: str = Field(default_factory=get_random_uuid, primary_key=True)
+    created_at: datetime = Field(default=datetime.now())
+    prompt: Optional[str] = None
+    title: Optional[str] = None
+    topic: Optional[str] = None
+    steps: Optional[List[dict]] = Field(sa_column=Column(JSON, nullable=True), default=None)
+    design: Optional[str] = None
+    image_url: Optional[str] = None

--- a/servers/nextjs/app/social/page.tsx
+++ b/servers/nextjs/app/social/page.tsx
@@ -54,6 +54,10 @@ export default function SocialPage() {
       const data = await res.json();
       setCaption(data.content);
       setImageUrl(data.image_url);
+      const saveBody = new FormData();
+      saveBody.append("caption", data.content);
+      saveBody.append("image_url", data.image_url);
+      await fetch("/api/v1/social/posts/save", { method: "POST", body: saveBody });
       let fetched = data.pages || [];
       if (allowedPages.length > 0) {
         fetched = fetched.filter((p: PageInfo) => allowedPages.includes(p.id));
@@ -93,7 +97,13 @@ export default function SocialPage() {
     body.append("file", manualFile);
     selected.forEach((id) => body.append("page_ids", id));
     const res = await fetch("/api/v1/social/publish", { method: "POST", body });
-    if (res.ok) alert("Published");
+    if (res.ok) {
+      alert("Published");
+      const saveBody = new FormData();
+      saveBody.append("caption", manualCaption);
+      saveBody.append("file", manualFile);
+      await fetch("/api/v1/social/posts/save", { method: "POST", body: saveBody });
+    }
   };
 
   const onManualFileChange = (file: File | null) => {


### PR DESCRIPTION
## Summary
- adjust prompt in flyer generator for sharp, legible text
- remove manual tab from flyer page
- automatically store generated flyers
- automatically store generated or published social posts
- add flyer and social post tables and routes on the server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6886ae721db8832daf7464bd15712510