### PR TITLE
Add loading indicators to admin, social, flyer pages

### DIFF
--- a/servers/nextjs/app/admin/page.tsx
+++ b/servers/nextjs/app/admin/page.tsx
@@ -5,6 +5,7 @@ import Wrapper from "@/components/Wrapper";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import ReactSelect from "react-select";
+import { OverlayLoader } from "@/components/ui/overlay-loader";
 
 interface PageInfo {
   id: string;
@@ -21,6 +22,7 @@ const AdminPage = () => {
   const [editing, setEditing] = useState<string | null>(null);
   const [editPassword, setEditPassword] = useState("");
   const [editPages, setEditPages] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
 
   const fetchUsers = async () => {
     const res = await fetch("/api/users");
@@ -43,6 +45,7 @@ const AdminPage = () => {
   }, []);
 
   const createUser = async () => {
+    setLoading(true);
     const res = await fetch("/api/users", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -58,10 +61,12 @@ const AdminPage = () => {
       const data = await res.json();
       setMessage(data.error || "Failed");
     }
+    setLoading(false);
   };
 
   const updateUser = async () => {
     if (!editing) return;
+    setLoading(true);
     const res = await fetch("/api/users", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -77,10 +82,12 @@ const AdminPage = () => {
       const data = await res.json();
       setMessage(data.error || "Failed");
     }
+    setLoading(false);
   };
 
   return (
     <div className="min-h-screen bg-[#E9E8F8]">
+      <OverlayLoader show={loading} text="Loading..." />
       <Header />
       <Wrapper className="py-10 max-w-xl space-y-4">
         <h2 className="text-xl font-medium">Create User</h2>
@@ -107,7 +114,7 @@ const AdminPage = () => {
             onChange={(opts) => setSelected(opts.map((o) => o.value as string))}
           />
         )}
-        <Button onClick={createUser}>Create User</Button>
+        <Button onClick={createUser} disabled={loading}>Create User</Button>
         {message && <p>{message}</p>}
         <hr className="my-4" />
         <h2 className="text-xl font-medium">Users</h2>
@@ -137,7 +144,7 @@ const AdminPage = () => {
                     />
                   )}
                   <div className="flex gap-2">
-                    <Button onClick={updateUser}>Save</Button>
+                    <Button onClick={updateUser} disabled={loading}>Save</Button>
                     <Button
                       variant="secondary"
                       onClick={() => {

--- a/servers/nextjs/app/flyer/page.tsx
+++ b/servers/nextjs/app/flyer/page.tsx
@@ -5,6 +5,7 @@ import Wrapper from "@/components/Wrapper";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { OverlayLoader } from "@/components/ui/overlay-loader";
 import ReactSelect from "react-select";
 
 export default function FlyerPage() {
@@ -19,6 +20,7 @@ export default function FlyerPage() {
   const [steps, setSteps] = useState<Step[]>([]);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [design, setDesign] = useState("cartoon");
+  const [loading, setLoading] = useState(false);
 
 
   const addStep = () => {
@@ -67,34 +69,40 @@ Use high contrast fonts so all text is easily readable. Make the layout vertical
   };
 
   const generate = async () => {
+    setLoading(true);
     const form = new FormData();
     const prompt = buildPrompt();
     form.append("text", prompt);
-    const res = await fetch("/api/v1/social/generate", {
-      method: "POST",
-      body: form,
-    });
-    if (res.ok) {
-      const data = await res.json();
-      setImageUrl(data.image_url);
-      await fetch("/api/v1/social/flyers/save", {
+    try {
+      const res = await fetch("/api/v1/social/generate", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          prompt,
-          title,
-          topic,
-          steps,
-          design,
-          image_url: data.image_url,
-        }),
+        body: form,
       });
+      if (res.ok) {
+        const data = await res.json();
+        setImageUrl(data.image_url);
+        await fetch("/api/v1/social/flyers/save", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            prompt,
+            title,
+            topic,
+            steps,
+            design,
+            image_url: data.image_url,
+          }),
+        });
+      }
+    } finally {
+      setLoading(false);
     }
   };
 
 
   return (
     <div className="min-h-screen bg-[#E9E8F8]">
+      <OverlayLoader show={loading} text="Loading..." />
       <Header />
       <Wrapper className="py-10 max-w-3xl space-y-4">
         <div className="space-y-4 bg-white rounded p-4">
@@ -147,7 +155,7 @@ Use high contrast fonts so all text is easily readable. Make the layout vertical
             <Button type="button" variant="secondary" onClick={addStep}>
               Add Step
             </Button>
-            <Button onClick={generate}>Generate Flyer</Button>
+            <Button onClick={generate} disabled={loading}>Generate Flyer</Button>
             {imageUrl && (
               <div className="flex justify-center pt-4">
                 <img src={imageUrl} alt="flyer" className="max-w-sm w-full" />


### PR DESCRIPTION
## Summary
- show `OverlayLoader` while flyer content is generated
- show `OverlayLoader` during social post actions
- show `OverlayLoader` for admin user management actions
- disable page action buttons while loading

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6886be845fcc832da0eface03a5255d5