### PR TITLE
Add LinkedIn publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You may want to directly provide your API KEYS as environment variables and keep
 - **PEXELS_API_KEY=[Your Pexels API Key]**: Provide this to generate images if **LLM** is set to **ollama** or **custom**
 - **FACEBOOK_TOKEN=[Facebook Access Token]**: Used for posting to Facebook pages.
 - **FACEBOOK_APP_ID=[Facebook App ID]** and **FACEBOOK_APP_SECRET=[Facebook App Secret]**: Optional. If provided, `FACEBOOK_TOKEN` will be automatically refreshed and persisted in `APP_DATA_DIRECTORY/facebook_token.txt`.
+- **LINKEDIN_TOKEN=[LinkedIn Access Token]**: Used for publishing to LinkedIn pages.
 
 ### Using OpenAI
 ```bash


### PR DESCRIPTION
## Summary
- support LinkedIn token in README
- enable LinkedIn page fetching and publishing in API
- add LinkedIn dropdown and publishing hooks in Social page

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `pytest` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6887829b6c24832da9cac7c5f4de4269