### PR TITLE
Add LinkedIn page permissions

### DIFF
--- a/servers/nextjs/app/api/auth/route.ts
+++ b/servers/nextjs/app/api/auth/route.ts
@@ -16,6 +16,7 @@ function loadUsers() {
       username: 'admin@clingroup.net',
       password: hashPassword('clingroup#123@'),
       pages: [],
+      linkedin_pages: [],
     });
     settingsStore.set(USERS_KEY, users);
   }
@@ -30,5 +31,9 @@ export async function POST(request: NextRequest) {
   if (!user) {
     return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
   }
-  return NextResponse.json({ username: user.username, pages: user.pages || [] });
+  return NextResponse.json({
+    username: user.username,
+    pages: user.pages || [],
+    linkedin_pages: user.linkedin_pages || [],
+  });
 }

--- a/servers/nextjs/app/api/users/route.ts
+++ b/servers/nextjs/app/api/users/route.ts
@@ -16,6 +16,7 @@ function loadUsers() {
       username: 'admin@clingroup.net',
       password: hashPassword('clingroup#123@'),
       pages: [],
+      linkedin_pages: [],
     });
     settingsStore.set(USERS_KEY, users);
   }
@@ -26,12 +27,16 @@ function saveUsers(users: any[]) {
 }
 
 export async function GET() {
-  const users = loadUsers().map((u: any) => ({ username: u.username, pages: u.pages || [] }));
+  const users = loadUsers().map((u: any) => ({
+    username: u.username,
+    pages: u.pages || [],
+    linkedin_pages: u.linkedin_pages || [],
+  }));
   return NextResponse.json({ users });
 }
 
 export async function POST(request: NextRequest) {
-  const { username, password, pages } = await request.json();
+  const { username, password, pages, linkedin_pages } = await request.json();
   if (!username || !password) {
     return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
   }
@@ -39,13 +44,18 @@ export async function POST(request: NextRequest) {
   if (users.some((u: any) => u.username === username)) {
     return NextResponse.json({ error: 'User exists' }, { status: 400 });
   }
-  users.push({ username, password: hashPassword(password), pages: pages || [] });
+  users.push({
+    username,
+    password: hashPassword(password),
+    pages: pages || [],
+    linkedin_pages: linkedin_pages || [],
+  });
   saveUsers(users);
   return NextResponse.json({ success: true });
 }
 
 export async function PUT(request: NextRequest) {
-  const { username, password, pages } = await request.json();
+  const { username, password, pages, linkedin_pages } = await request.json();
   if (!username) {
     return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
   }
@@ -59,6 +69,9 @@ export async function PUT(request: NextRequest) {
   }
   if (pages) {
     user.pages = pages;
+  }
+  if (linkedin_pages) {
+    user.linkedin_pages = linkedin_pages;
   }
   saveUsers(users);
   return NextResponse.json({ success: true });

--- a/servers/nextjs/app/social/page.tsx
+++ b/servers/nextjs/app/social/page.tsx
@@ -30,6 +30,9 @@ export default function SocialPage() {
   const [selectedLinkedin, setSelectedLinkedin] = useState<string[]>([]);
 
   const allowedPages = useSelector((state: RootState) => state.auth.pages);
+  const allowedLinkedinPages = useSelector(
+    (state: RootState) => state.auth.linkedinPages,
+  );
 
   const [manualCaption, setManualCaption] = useState("");
   const [manualFile, setManualFile] = useState<File | null>(null);
@@ -55,16 +58,21 @@ export default function SocialPage() {
       const res = await fetch("/api/v1/social/linkedin/pages");
       if (res.ok) {
         const data = await res.json();
-        const fetched = (data.pages || []).map((p: any) => ({
+        let fetched = (data.pages || []).map((p: any) => ({
           id: p.id,
           name: p.name,
           accountId: p.account_id,
         }));
+        if (allowedLinkedinPages.length > 0) {
+          fetched = fetched.filter((p: any) =>
+            allowedLinkedinPages.includes(`${p.accountId}:${p.id}`),
+          );
+        }
         setLinkedinPages(fetched);
       }
     };
     fetchLinkedinPages();
-  }, [allowedPages]);
+  }, [allowedPages, allowedLinkedinPages]);
 
   const generate = async () => {
     setLoading(true);
@@ -242,40 +250,46 @@ export default function SocialPage() {
             )}
           </TabsContent>
           {pages.length > 0 && (
-            <ReactSelect
-              isMulti
-              className="basic-multi-select"
-              classNamePrefix="select"
-              options={pages.map((p) => ({ value: p.id, label: p.name }))}
-              value={pages
-                .filter((p) => selected.includes(p.id))
-                .map((p) => ({ value: p.id, label: p.name }))}
-              onChange={(options) =>
-                setSelected(options.map((o) => o.value as string))
-              }
-            />
+            <div className="space-y-2">
+              <p className="font-medium">Facebook</p>
+              <ReactSelect
+                isMulti
+                className="basic-multi-select"
+                classNamePrefix="select"
+                options={pages.map((p) => ({ value: p.id, label: p.name }))}
+                value={pages
+                  .filter((p) => selected.includes(p.id))
+                  .map((p) => ({ value: p.id, label: p.name }))}
+                onChange={(options) =>
+                  setSelected(options.map((o) => o.value as string))
+                }
+              />
+            </div>
           )}
           {linkedinPages.length > 0 && (
-            <ReactSelect
-              isMulti
-              className="basic-multi-select"
-              classNamePrefix="select"
-              options={linkedinPages.map((p) => ({
-                value: `${p.accountId}:${p.id}`,
-                label: p.name,
-              }))}
-              value={linkedinPages
-                .filter((p) =>
-                  selectedLinkedin.includes(`${p.accountId}:${p.id}`),
-                )
-                .map((p) => ({
+            <div className="space-y-2">
+              <p className="font-medium">LinkedIn</p>
+              <ReactSelect
+                isMulti
+                className="basic-multi-select"
+                classNamePrefix="select"
+                options={linkedinPages.map((p) => ({
                   value: `${p.accountId}:${p.id}`,
                   label: p.name,
                 }))}
-              onChange={(opts) =>
-                setSelectedLinkedin(opts.map((o) => o.value as string))
-              }
-            />
+                value={linkedinPages
+                  .filter((p) =>
+                    selectedLinkedin.includes(`${p.accountId}:${p.id}`),
+                  )
+                  .map((p) => ({
+                    value: `${p.accountId}:${p.id}`,
+                    label: p.name,
+                  }))}
+                onChange={(opts) =>
+                  setSelectedLinkedin(opts.map((o) => o.value as string))
+                }
+              />
+            </div>
           )}
           {selected.length + selectedLinkedin.length > 0 && (
             <div className="flex gap-4">

--- a/servers/nextjs/components/auth/LoginForm.tsx
+++ b/servers/nextjs/components/auth/LoginForm.tsx
@@ -21,7 +21,13 @@ const LoginForm = () => {
     });
     if (res.ok) {
       const data = await res.json();
-      dispatch(login({ user: data.username, pages: data.pages }));
+      dispatch(
+        login({
+          user: data.username,
+          pages: data.pages,
+          linkedinPages: data.linkedin_pages,
+        }),
+      );
       router.push("/");
     } else {
       setError("Invalid credentials");

--- a/servers/nextjs/store/slices/auth.ts
+++ b/servers/nextjs/store/slices/auth.ts
@@ -5,27 +5,39 @@ export interface AuthState {
   isLoggedIn: boolean;
   user?: string;
   pages: string[];
+  linkedinPages: string[];
 }
 
 export const initialAuthState: AuthState = {
   isLoggedIn: false,
   pages: [],
+  linkedinPages: [],
 };
 
 const authSlice = createSlice({
   name: "auth",
   initialState: initialAuthState,
   reducers: {
-    login: (state, action: PayloadAction<{ user: string; pages: string[] }>) => {
+    login: (
+      state,
+      action: PayloadAction<{ user: string; pages: string[]; linkedinPages: string[] }>,
+    ) => {
       state.isLoggedIn = true;
       state.user = action.payload.user;
       state.pages = action.payload.pages;
-      saveAuthState({ isLoggedIn: true, user: state.user, pages: state.pages });
+      state.linkedinPages = action.payload.linkedinPages;
+      saveAuthState({
+        isLoggedIn: true,
+        user: state.user,
+        pages: state.pages,
+        linkedinPages: state.linkedinPages,
+      });
     },
     logout: (state) => {
       state.isLoggedIn = false;
       state.user = undefined;
       state.pages = [];
+      state.linkedinPages = [];
       clearAuthState();
     },
   },

--- a/servers/nextjs/utils/authStorage.ts
+++ b/servers/nextjs/utils/authStorage.ts
@@ -2,6 +2,7 @@ export interface StoredAuthState {
   isLoggedIn: boolean;
   user?: string;
   pages: string[];
+  linkedinPages: string[];
 }
 
 export function loadAuthState(): StoredAuthState | undefined {
@@ -9,7 +10,9 @@ export function loadAuthState(): StoredAuthState | undefined {
   try {
     const data = localStorage.getItem('auth');
     if (!data) return undefined;
-    return JSON.parse(data) as StoredAuthState;
+    const parsed = JSON.parse(data) as StoredAuthState;
+    parsed.linkedinPages = parsed.linkedinPages || [];
+    return parsed;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- extend user data to store linkedin_pages
- allow admin to manage LinkedIn page permissions
- persist LinkedIn permissions in auth state
- show Facebook and LinkedIn page selectors with titles

## Testing
- `npm install` *(installs Next.js dependencies)*
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887ba3d3ebc832d80bbb851fc876f2b