### PR TITLE
Fix PDF export bypassing login

### DIFF
--- a/servers/nextjs/app/api/slide-metadata/route.ts
+++ b/servers/nextjs/app/api/slide-metadata/route.ts
@@ -103,6 +103,17 @@ export async function POST(request: NextRequest) {
 
     const page = await browser.newPage();
     await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
+    // Bypass the login screen when the pdf-maker page is loaded by Puppeteer.
+    // The frontend stores authentication state in localStorage, so we prefill
+    // the expected structure before navigation. This mirrors the approach used
+    // by the PDF export route and avoids redirection to the login page during
+    // slide metadata collection.
+    await page.evaluateOnNewDocument(() => {
+      localStorage.setItem(
+        'auth',
+        JSON.stringify({ isLoggedIn: true, pages: [], linkedinPages: [] })
+      );
+    });
 
     try {
       await page.goto(`http://localhost/pdf-maker?id=${id}`, {


### PR DESCRIPTION
## Summary
- ensure the PDF export route preloads auth in localStorage
- inject the same auth prep in slide-metadata route so PPTX exports succeed

## Testing
- `npm run lint` *(fails: next not found)*
- `pip install -r requirements.txt` *(fails: fastembed_vectorstore not found)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6889ed3bd1f4832d8f0e2e866ef57aea