### PR TITLE
Add dropdown controls for image generation

### DIFF
--- a/servers/fastapi/api/routers/social/router.py
+++ b/servers/fastapi/api/routers/social/router.py
@@ -3,6 +3,7 @@ import os
 import re
 import uuid
 from typing import List, Optional
+import base64
 
 import requests
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
@@ -138,27 +139,52 @@ async def _generate_content(text: str, client: AsyncOpenAI) -> dict:
     return extract_json_block(content)
 
 
-async def _generate_image(summary_text: str, client: AsyncOpenAI) -> str:
-    flyer_prompt = (
-        "Design a vertical marketing flyer based on the following summary. "
-        "Layout should include a bold title area, clear blocks for key benefits or services, and a footer with contact info. "
-        "Use a modern editorial infographic style with clean icons or illustrations, pastel background, and contrasting accent colors. "
-        "Make the flyer easy to read and engaging for both print and digital use. "
-        f"Marketing summary:\n{summary_text}"
-    )
+async def _generate_image(
+    prompt_text: str,
+    client: AsyncOpenAI,
+    *,
+    mode: str = "flyer",
+    size: str = "1024x1024",
+    quality: str = "medium",
+    output_format: str = "png",
+    background: str = "opaque",
+    moderation: str = "auto",
+    text_amount: str = "medium",
+) -> str:
+    """Generate an image or flyer using OpenAI's image API."""
+
+    amount_map = {
+        "low": "Use minimal text in the design.",
+        "medium": "Use a moderate amount of text in the design.",
+        "high": "Include a large amount of text in the design.",
+    }
+    amount_instruction = amount_map.get(text_amount, amount_map["medium"])
+
+    if mode == "flyer":
+        prompt = (
+            "Design a vertical marketing flyer based on the following summary. "
+            "Layout should include a bold title area, clear blocks for key benefits or services, and a footer with contact info. "
+            "Use a modern editorial infographic style with clean icons or illustrations, pastel background, and contrasting accent colors. "
+            "Make the flyer easy to read and engaging for both print and digital use. "
+            f"{amount_instruction} "
+            f"Marketing summary:\n{prompt_text}"
+        )
+    else:
+        prompt = f"{prompt_text}. {amount_instruction}"
 
     resp = await client.images.generate(
         model="gpt-image-1",
-        prompt=flyer_prompt,
+        prompt=prompt,
         n=1,
-        size="1024x1024",
-        quality="medium",
-        output_format="png",
-        background="opaque",
-        moderation="auto"
+        size=size,
+        quality=quality,
+        output_format=output_format,
+        background=background,
+        moderation=moderation,
+        text_amount=text_amount,
     )
     b64 = resp.data[0].b64_json
-    return f"data:image/png;base64,{b64}"
+    return f"data:image/{output_format};base64,{b64}"
 
 
 
@@ -209,20 +235,38 @@ async def get_linkedin_pages():
 
 @social_router.post("/generate")
 async def generate(
-    text: Optional[str] = Form(None), file: Optional[UploadFile] = File(None)
+    text: Optional[str] = Form(None),
+    file: Optional[UploadFile] = File(None),
+    mode: str = Form("flyer"),
+    size: str = Form("1024x1024"),
+    quality: str = Form("medium"),
+    output_format: str = Form("png"),
+    background: str = Form("opaque"),
+    moderation: str = Form("auto"),
+    text_amount: str = Form("medium"),
 ):
     if not text and not file:
         raise HTTPException(status_code=400, detail="Provide text or audio")
-    
+
     client = AsyncOpenAI()
-    
+
     if file:
         text = await _transcribe_audio(file, client)
 
     data = await _generate_content(text, client)
-    image_url = await _generate_image(data["content"], client)  # 🔁 ملخص التسويق بدل الـ prompt
+    prompt_text = data["content"] if mode == "flyer" else data.get("image_prompt", text)
+    image_url = await _generate_image(
+        prompt_text,
+        client,
+        mode=mode,
+        size=size,
+        quality=quality,
+        output_format=output_format,
+        background=background,
+        moderation=moderation,
+    )
     pages = _get_pages()
-    
+
     return {"content": data["content"], "image_url": image_url, "pages": pages}
 
 
@@ -279,8 +323,7 @@ async def publish(
     return {"results": results}
 
 
-from fastapi import UploadFile
-import base64
+
 
 @social_router.post("/linkedin/publish")
 async def publish_linkedin(

--- a/servers/nextjs/app/social/page.tsx
+++ b/servers/nextjs/app/social/page.tsx
@@ -39,6 +39,14 @@ export default function SocialPage() {
   const [manualPreview, setManualPreview] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
+  const [mode, setMode] = useState("flyer");
+  const [size, setSize] = useState("1024x1024");
+  const [quality, setQuality] = useState("medium");
+  const [outputFormat, setOutputFormat] = useState("png");
+  const [background, setBackground] = useState("opaque");
+  const [moderation, setModeration] = useState("auto");
+  const [textAmount, setTextAmount] = useState("medium");
+
   useEffect(() => {
     const fetchPages = async () => {
       const res = await fetch("/api/v1/social/pages");
@@ -78,6 +86,13 @@ export default function SocialPage() {
     setLoading(true);
     const form = new FormData();
     if (text) form.append("text", text);
+    form.append("mode", mode);
+    form.append("size", size);
+    form.append("quality", quality);
+    form.append("output_format", outputFormat);
+    form.append("background", background);
+    form.append("moderation", moderation);
+    form.append("text_amount", textAmount);
     try {
       const res = await fetch("/api/v1/social/generate", {
         method: "POST",
@@ -138,6 +153,13 @@ export default function SocialPage() {
     if (!caption) return;
     const form = new FormData();
     form.append("text", caption);
+    form.append("mode", mode);
+    form.append("size", size);
+    form.append("quality", quality);
+    form.append("output_format", outputFormat);
+    form.append("background", background);
+    form.append("moderation", moderation);
+    form.append("text_amount", textAmount);
     setLoading(true);
     try {
       const res = await fetch("/api/v1/social/generate", {
@@ -212,6 +234,91 @@ export default function SocialPage() {
               value={text}
               onChange={(e) => setText(e.target.value)}
             />
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="text-sm">Type</label>
+                <select
+                  value={mode}
+                  onChange={(e) => setMode(e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                >
+                  <option value="flyer">Flyer</option>
+                  <option value="image">Image</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm">Size</label>
+                <select
+                  value={size}
+                  onChange={(e) => setSize(e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                >
+                  <option value="1024x1024">1024x1024</option>
+                  <option value="1792x1024">1792x1024</option>
+                  <option value="1024x1792">1024x1792</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm">Quality</label>
+                <select
+                  value={quality}
+                  onChange={(e) => setQuality(e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                >
+                  <option value="standard">standard</option>
+                  <option value="hd">hd</option>
+                  <option value="medium">medium</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm">Format</label>
+                <select
+                  value={outputFormat}
+                  onChange={(e) => setOutputFormat(e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                >
+                  <option value="png">png</option>
+                  <option value="jpeg">jpeg</option>
+                  <option value="webp">webp</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm">Background</label>
+                <select
+                  value={background}
+                  onChange={(e) => setBackground(e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                >
+                  <option value="opaque">opaque</option>
+                  <option value="transparent">transparent</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm">Moderation</label>
+                <select
+                  value={moderation}
+                  onChange={(e) => setModeration(e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                >
+                  <option value="auto">auto</option>
+                  <option value="strict">strict</option>
+                  <option value="soft">soft</option>
+                  <option value="none">none</option>
+                </select>
+              </div>
+              <div className="col-span-2">
+                <label className="text-sm">Text Amount</label>
+                <select
+                  value={textAmount}
+                  onChange={(e) => setTextAmount(e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                >
+                  <option value="low">low</option>
+                  <option value="medium">medium</option>
+                  <option value="high">high</option>
+                </select>
+              </div>
+            </div>
             <Button onClick={generate} disabled={loading}>
               Generate
             </Button>
@@ -222,15 +329,30 @@ export default function SocialPage() {
                   onChange={(e) => setCaption(e.target.value)}
                 />
                 {imageUrl && (
-                  <img src={imageUrl} alt="generated" className="max-w-sm" />
+                  <div className="space-y-2">
+                    <img src={imageUrl} alt="generated" className="max-w-sm" />
+                    <div className="flex gap-2">
+                      <Button
+                        variant="secondary"
+                        onClick={() => {
+                          const a = document.createElement("a");
+                          a.href = imageUrl;
+                          a.download = `image.${outputFormat}`;
+                          a.click();
+                        }}
+                      >
+                        Download Image
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        onClick={regenerateImage}
+                        disabled={loading}
+                      >
+                        Regenerate Image
+                      </Button>
+                    </div>
+                  </div>
                 )}
-                <Button
-                  variant="secondary"
-                  onClick={regenerateImage}
-                  disabled={loading}
-                >
-                  Regenerate Image
-                </Button>
               </div>
             )}
           </TabsContent>


### PR DESCRIPTION
## Summary
- extend OpenAI generation options with `text_amount`
- expose size/quality/format/background/moderation as dropdowns
- allow adjusting text amount via new dropdown
- include text amount in regenerate image calls
- add download button for generated image

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*
- `npm run build` *(fails: ENOENT: no such file or directory 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688b43aff77c832d8284513e628f02fd