### PR TITLE
feat: weekly post planner and flyer generation

### DIFF
--- a/servers/fastapi/api/routers/social/router.py
+++ b/servers/fastapi/api/routers/social/router.py
@@ -2,8 +2,10 @@ import json
 import os
 import re
 import uuid
+from datetime import datetime
 from typing import List, Optional
 import base64
+import asyncio
 
 import requests
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
@@ -115,6 +117,18 @@ def extract_json_block(text: str) -> dict:
         )
 
 
+def extract_json_array(text: str) -> List[dict]:
+    try:
+        match = re.search(r"\[.*\]", text, re.DOTALL)
+        if not match:
+            raise ValueError("No JSON array found in LLM response")
+        return json.loads(match.group(0))
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to parse LLM response: {str(e)}"
+        )
+
+
 async def _generate_content(text: str, client: AsyncOpenAI) -> dict:
     system = (
         "You are a professional marketing copywriter for flyers and landing pages. "
@@ -206,6 +220,24 @@ async def _generate_image(
     return f"data:image/{output_format};base64,{b64}"
 
 
+async def _generate_weekly_posts(text: str, client: AsyncOpenAI) -> List[dict]:
+    system = (
+        "You are a social media assistant. Given a topic or description, "
+        "create exactly seven engaging social media posts for a week. "
+        "Return a JSON array with seven objects each containing 'caption' and 'image_prompt'."
+    )
+
+    resp = await client.chat.completions.create(
+        model=OPENAI_MODEL,
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": text},
+        ],
+    )
+    content = resp.choices[0].message.content
+    return extract_json_array(content)
+
+
 
 
 def _get_pages():
@@ -293,6 +325,27 @@ async def generate(
     pages = _get_pages()
 
     return {"content": data["content"], "image_url": image_url, "pages": pages}
+
+
+@social_router.post("/generate/week")
+async def generate_week(text: str = Form(...)):
+    client = AsyncOpenAI()
+    items = await _generate_weekly_posts(text, client)
+
+    async def build_post(item: dict) -> dict:
+        try:
+            image_task = _generate_image(
+                item.get("image_prompt", ""),
+                client,
+                mode="image",
+            )
+            image_url = await asyncio.wait_for(image_task, timeout=60)
+        except Exception:
+            image_url = ""
+        return {"caption": item.get("caption", ""), "image_url": image_url}
+
+    posts = await asyncio.gather(*(build_post(it) for it in items))
+    return {"posts": posts}
 
 
 
@@ -440,6 +493,7 @@ async def save_post(
     caption: str = Form(...),
     image_url: Optional[str] = Form(None),
     file: Optional[UploadFile] = File(None),
+    scheduled_for: Optional[str] = Form(None),
 ):
     path = None
     if file:
@@ -448,8 +502,65 @@ async def save_post(
         with open(path, "wb") as f:
             f.write(await file.read())
 
+    scheduled_dt = (
+        datetime.fromisoformat(scheduled_for) if scheduled_for else None
+    )
+
     with get_sql_session() as session:
-        post = SocialPostSqlModel(caption=caption, image_url=image_url, file=path)
+        post = SocialPostSqlModel(
+            caption=caption,
+            image_url=image_url,
+            file=path,
+            scheduled_for=scheduled_dt,
+        )
+        session.add(post)
+        session.commit()
+        session.refresh(post)
+        return post
+
+
+class PostData(BaseModel):
+    caption: str
+    image_url: Optional[str] = None
+    scheduled_for: Optional[datetime] = None
+
+
+class BulkPosts(BaseModel):
+    posts: List[PostData]
+
+
+class PostUpdate(BaseModel):
+    caption: Optional[str] = None
+    image_url: Optional[str] = None
+    scheduled_for: Optional[datetime] = None
+
+
+@social_router.post("/posts/bulk")
+async def save_posts_bulk(data: BulkPosts):
+    with get_sql_session() as session:
+        posts = []
+        for item in data.posts:
+            post = SocialPostSqlModel(
+                caption=item.caption,
+                image_url=item.image_url,
+                scheduled_for=item.scheduled_for,
+            )
+            session.add(post)
+            posts.append(post)
+        session.commit()
+        for p in posts:
+            session.refresh(p)
+    return posts
+
+
+@social_router.put("/posts/{post_id}")
+async def update_post(post_id: str, data: PostUpdate):
+    with get_sql_session() as session:
+        post = session.get(SocialPostSqlModel, post_id)
+        if not post:
+            raise HTTPException(status_code=404, detail="Post not found")
+        for k, v in data.model_dump(exclude_unset=True).items():
+            setattr(post, k, v)
         session.add(post)
         session.commit()
         session.refresh(post)

--- a/servers/fastapi/api/sql_models.py
+++ b/servers/fastapi/api/sql_models.py
@@ -66,6 +66,7 @@ class SocialPostSqlModel(SQLModel, table=True):
     caption: str
     image_url: Optional[str] = None
     file: Optional[str] = None
+    scheduled_for: Optional[datetime] = None
 
 class FlyerSqlModel(SQLModel, table=True):
     id: str = Field(default_factory=get_random_uuid, primary_key=True)

--- a/servers/nextjs/app/social/calendar/page.tsx
+++ b/servers/nextjs/app/social/calendar/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+import { useState } from "react";
+import Header from "@/app/dashboard/components/Header";
+import Wrapper from "@/components/Wrapper";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+
+interface Post {
+  caption: string;
+  imageUrl: string | null;
+  date: string;
+}
+
+const dayNames = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+export default function SocialCalendarPage() {
+  const [topic, setTopic] = useState("");
+  const [posts, setPosts] = useState<Post[]>(() => {
+    const today = new Date();
+    const start = new Date(today);
+    start.setDate(today.getDate() - today.getDay());
+    return Array.from({ length: 7 }).map((_, i) => {
+      const d = new Date(start);
+      d.setDate(start.getDate() + i);
+      return { caption: "", imageUrl: null, date: d.toISOString() };
+    });
+  });
+  const [saving, setSaving] = useState(false);
+  const [generated, setGenerated] = useState(false);
+
+  const generateWeek = async () => {
+    if (!topic) return;
+    const form = new FormData();
+    form.append("text", topic);
+    const res = await fetch("/api/v1/social/generate/week", {
+      method: "POST",
+      body: form,
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setPosts((prev) =>
+        prev.map((p, i) => ({
+          ...p,
+          caption: data.posts[i]?.caption || "",
+          imageUrl: data.posts[i]?.image_url || null,
+        })),
+      );
+      setGenerated(true);
+    }
+  };
+
+  const saveAll = async () => {
+    setSaving(true);
+    await fetch("/api/v1/social/posts/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        posts: posts.map((p) => ({
+          caption: p.caption,
+          image_url: p.imageUrl,
+          scheduled_for: p.date,
+        })),
+      }),
+    });
+    setSaving(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-[#E9E8F8]">
+      <Header />
+      <Wrapper className="py-10 max-w-4xl space-y-6">
+        <div className="bg-white p-6 rounded space-y-4">
+          <h2 className="text-xl font-bold">Weekly Post Planner</h2>
+          <Input
+            placeholder="Topic for the week"
+            value={topic}
+            onChange={(e) => setTopic(e.target.value)}
+          />
+          <Button onClick={generateWeek} disabled={!topic}>
+            Generate Week
+          </Button>
+        </div>
+        {generated && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {posts.map((post, idx) => (
+              <div key={idx} className="bg-white p-4 rounded space-y-2">
+                <h3 className="font-semibold">{dayNames[idx]}</h3>
+                <Textarea
+                  value={post.caption}
+                  onChange={(e) =>
+                    setPosts((prev) =>
+                      prev.map((p, i) =>
+                        i === idx ? { ...p, caption: e.target.value } : p,
+                      ),
+                    )
+                  }
+                  placeholder="Caption"
+                />
+                {post.imageUrl && (
+                  <img src={post.imageUrl} alt="post" className="rounded" />
+                )}
+                <Input
+                  placeholder="Image URL"
+                  value={post.imageUrl || ""}
+                  onChange={(e) =>
+                    setPosts((prev) =>
+                      prev.map((p, i) =>
+                        i === idx ? { ...p, imageUrl: e.target.value } : p,
+                      ),
+                    )
+                  }
+                />
+              </div>
+            ))}
+          </div>
+        )}
+        {generated && (
+          <Button onClick={saveAll} disabled={saving}>
+            Save Posts
+          </Button>
+        )}
+      </Wrapper>
+    </div>
+  );
+}

--- a/servers/nextjs/app/social/page.tsx
+++ b/servers/nextjs/app/social/page.tsx
@@ -10,6 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSelector } from "react-redux";
 import { RootState } from "@/store/store";
 import { OverlayLoader } from "@/components/ui/overlay-loader";
+import Link from "next/link";
 
 // ------- إضافة الأمثلة والستايلات والألوان -------
 const STYLES = [
@@ -279,6 +280,11 @@ export default function SocialPage() {
     <div className="min-h-screen bg-[#E9E8F8]">
       <OverlayLoader show={loading} text="Loading..." />
       <Header />
+      <div className="p-4 text-right">
+        <Link href="/social/calendar" className="text-sm underline">
+          Weekly planner
+        </Link>
+      </div>
       <Wrapper className="py-10 max-w-2xl">
         <Tabs defaultValue="ai" className="w-full space-y-6">
           <TabsList className="w-full flex justify-center mb-4">


### PR DESCRIPTION
## Summary
- support scheduling posts with new `scheduled_for` field and bulk save/update endpoints
- add weekly post generation API and calendar UI for seven-day planning
- link calendar from social page and enable flyer image creation via AI
- parallelize weekly image generation to speed up schedule creation and avoid timeouts

## Testing
- `pip install $(grep -v fastembed_vectorstore servers/fastapi/requirements.txt | tr '\n' ' ')`
- `pytest servers/fastapi/tests` *(fails: ModuleNotFoundError: No module named 'api')*
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory, open '/workspace/presenton/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68adfa4b3c3c832d8b1f4b506fc8c4b1