### PR TITLE
feat: add image album for social posts

### DIFF
--- a/servers/fastapi/api/routers/social/router.py
+++ b/servers/fastapi/api/routers/social/router.py
@@ -98,6 +98,23 @@ def _refresh_token(token: str) -> str:
     return token
 
 
+def _save_image_to_album(url: str) -> str:
+    """Download or decode an image and store it in the posts album."""
+    os.makedirs(os.path.join(APP_DATA_DIR, "posts"), exist_ok=True)
+    filename = f"{uuid.uuid4()}.png"
+    path = os.path.join(APP_DATA_DIR, "posts", filename)
+    if url.startswith("data:"):
+        _, b64data = url.split(",", 1)
+        data = base64.b64decode(b64data)
+    else:
+        resp = requests.get(url)
+        resp.raise_for_status()
+        data = resp.content
+    with open(path, "wb") as f:
+        f.write(data)
+    return path
+
+
 async def _transcribe_audio(file: UploadFile, client: AsyncOpenAI) -> str:
     data = await file.read()
     return await client.audio.transcriptions.create(
@@ -501,6 +518,12 @@ async def save_post(
         path = os.path.join(APP_DATA_DIR, "posts", f"{uuid.uuid4()}_{file.filename}")
         with open(path, "wb") as f:
             f.write(await file.read())
+    elif image_url:
+        try:
+            path = _save_image_to_album(image_url)
+            image_url = None
+        except Exception:
+            pass
 
     scheduled_dt = (
         datetime.fromisoformat(scheduled_for) if scheduled_for else None
@@ -540,9 +563,18 @@ async def save_posts_bulk(data: BulkPosts):
     with get_sql_session() as session:
         posts = []
         for item in data.posts:
+            path = None
+            image_url = item.image_url
+            if image_url:
+                try:
+                    path = _save_image_to_album(image_url)
+                    image_url = None
+                except Exception:
+                    pass
             post = SocialPostSqlModel(
                 caption=item.caption,
-                image_url=item.image_url,
+                image_url=image_url,
+                file=path,
                 scheduled_for=item.scheduled_for,
             )
             session.add(post)
@@ -573,6 +605,21 @@ async def get_posts():
         posts = session.exec(select(SocialPostSqlModel)).all()
     posts.sort(key=lambda x: x.created_at, reverse=True)
     return posts
+
+
+@social_router.get("/images")
+async def get_album_images():
+    dir_path = os.path.join(APP_DATA_DIR, "posts")
+    images: List[str] = []
+    if os.path.exists(dir_path):
+        for name in os.listdir(dir_path):
+            try:
+                with open(os.path.join(dir_path, name), "rb") as f:
+                    b64 = base64.b64encode(f.read()).decode("utf-8")
+                    images.append(f"data:image/png;base64,{b64}")
+            except Exception:
+                continue
+    return {"images": images}
 
 
 class FlyerData(BaseModel):

--- a/servers/nextjs/app/social/calendar/page.tsx
+++ b/servers/nextjs/app/social/calendar/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Header from "@/app/dashboard/components/Header";
 import Wrapper from "@/components/Wrapper";
 import { Input } from "@/components/ui/input";
@@ -36,6 +36,19 @@ export default function SocialCalendarPage() {
   });
   const [saving, setSaving] = useState(false);
   const [generated, setGenerated] = useState(false);
+  const [album, setAlbum] = useState<string[]>([]);
+
+  const fetchAlbum = async () => {
+    const res = await fetch("/api/v1/social/images");
+    if (res.ok) {
+      const data = await res.json();
+      setAlbum(data.images || []);
+    }
+  };
+
+  useEffect(() => {
+    fetchAlbum();
+  }, []);
 
   const generateWeek = async () => {
     if (!topic) return;
@@ -72,6 +85,7 @@ export default function SocialCalendarPage() {
       }),
     });
     setSaving(false);
+    fetchAlbum();
   };
 
   return (
@@ -119,6 +133,24 @@ export default function SocialCalendarPage() {
                     )
                   }
                 />
+                {album.length > 0 && (
+                  <div className="flex gap-2 overflow-x-auto py-2">
+                    {album.map((img, i) => (
+                      <img
+                        key={i}
+                        src={img}
+                        onClick={() =>
+                          setPosts((prev) =>
+                            prev.map((p, j) =>
+                              j === idx ? { ...p, imageUrl: img } : p,
+                            ),
+                          )
+                        }
+                        className="w-16 h-16 object-cover rounded cursor-pointer border"
+                      />
+                    ))}
+                  </div>
+                )}
               </div>
             ))}
           </div>

--- a/servers/nextjs/app/social/page.tsx
+++ b/servers/nextjs/app/social/page.tsx
@@ -94,6 +94,31 @@ export default function SocialPage() {
   const [manualFile, setManualFile] = useState<File | null>(null);
   const [manualPreview, setManualPreview] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [album, setAlbum] = useState<string[]>([]);
+
+  const fetchAlbum = async () => {
+    const res = await fetch("/api/v1/social/images");
+    if (res.ok) {
+      const data = await res.json();
+      setAlbum(data.images || []);
+    }
+  };
+
+  useEffect(() => {
+    fetchAlbum();
+  }, []);
+
+  const dataUrlToFile = (src: string) => {
+    const arr = src.split(",");
+    const mime = arr[0].match(/:(.*?);/)?[1] || "image/png";
+    const bstr = atob(arr[1]);
+    let n = bstr.length;
+    const u8arr = new Uint8Array(n);
+    while (n--) {
+      u8arr[n] = bstr.charCodeAt(n);
+    }
+    return new File([u8arr], "image.png", { type: mime });
+  };
 
   const [mode, setMode] = useState("flyer");
   const [size, setSize] = useState("1024x1024");
@@ -167,6 +192,7 @@ export default function SocialPage() {
           method: "POST",
           body: saveBody,
         });
+        fetchAlbum();
         let fetched = data.pages || [];
         if (allowedPages.length > 0) {
           fetched = fetched.filter((p: any) => allowedPages.includes(p.id));
@@ -262,6 +288,7 @@ export default function SocialPage() {
         method: "POST",
         body: saveBody,
       });
+      fetchAlbum();
     } finally {
       setLoading(false);
     }
@@ -529,6 +556,25 @@ export default function SocialPage() {
             </div>
           )}
         </Tabs>
+        {album.length > 0 && (
+          <div className="bg-white p-4 rounded space-y-2">
+            <h3 className="font-semibold">Saved Images</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+              {album.map((img, i) => (
+                <img
+                  key={i}
+                  src={img}
+                  className="rounded cursor-pointer"
+                  onClick={() => {
+                    const file = dataUrlToFile(img);
+                    setManualFile(file);
+                    setManualPreview(img);
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+        )}
       </Wrapper>
     </div>
   );


### PR DESCRIPTION
## Summary
- store post images to a local album and expose them via `/api/v1/social/images`
- save images when adding individual or bulk posts
- show saved images in social pages so marketers can reuse them

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies fastembed_vectorstore)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'uvicorn')*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompt for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4830bad0832d8016a44805cad14b