### PR TITLE
feat: add Excel import and gallery pages

### DIFF
--- a/servers/nextjs/app/social/import/page.tsx
+++ b/servers/nextjs/app/social/import/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+import { useState, useEffect } from "react";
+import Header from "@/app/dashboard/components/Header";
+import Wrapper from "@/components/Wrapper";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import * as XLSX from "xlsx";
+
+interface Row {
+  content: string;
+  textAmount: string;
+  style: string;
+  dominantColor: string;
+  type: string;
+  size: string;
+  publishDateTime: string;
+  imageUrl?: string;
+}
+
+export default function ImportPage() {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [pages, setPages] = useState<any[]>([]);
+  const [linkedinPages, setLinkedinPages] = useState<any[]>([]);
+
+  useEffect(() => {
+    const fetchPages = async () => {
+      const res = await fetch("/api/v1/social/pages");
+      if (res.ok) {
+        const data = await res.json();
+        setPages(data.pages || []);
+      }
+    };
+    const fetchLinkedin = async () => {
+      const res = await fetch("/api/v1/social/linkedin/pages");
+      if (res.ok) {
+        const data = await res.json();
+        setLinkedinPages(data.pages || []);
+      }
+    };
+    fetchPages();
+    fetchLinkedin();
+  }, []);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const data = await file.arrayBuffer();
+    const workbook = XLSX.read(data, { type: "array" });
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const json: any[] = XLSX.utils.sheet_to_json(sheet, {
+      header: [
+        "content",
+        "textAmount",
+        "style",
+        "dominantColor",
+        "type",
+        "size",
+        "publishDateTime",
+      ],
+      range: 1,
+      defval: "",
+    });
+    setRows(json as Row[]);
+  };
+
+  const generateImage = async (idx: number) => {
+    const row = rows[idx];
+    const form = new FormData();
+    form.append("text", row.content);
+    form.append("mode", row.type || "image");
+    form.append("size", row.size || "1024x1024");
+    form.append("text_amount", row.textAmount || "medium");
+    form.append("style", row.style || "professional");
+    form.append("dominant_color", row.dominantColor || "blue");
+    const res = await fetch("/api/v1/social/generate", {
+      method: "POST",
+      body: form,
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const saveBody = new FormData();
+      saveBody.append("caption", row.content);
+      saveBody.append("image_url", data.image_url);
+      await fetch("/api/v1/social/posts/save", { method: "POST", body: saveBody });
+      setRows((prev) =>
+        prev.map((r, i) => (i === idx ? { ...r, imageUrl: data.image_url } : r)),
+      );
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#E9E8F8]">
+      <Header />
+      <Wrapper className="py-10 space-y-6 max-w-5xl">
+        <div className="bg-white p-6 rounded space-y-4">
+          <h2 className="text-xl font-bold">Import Posts</h2>
+          <Input type="file" accept=".xlsx,.xls" onChange={handleFile} />
+        </div>
+        {rows.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="min-w-full bg-white rounded">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Content</th>
+                  <th className="p-2">Text Amount</th>
+                  <th className="p-2">Style</th>
+                  <th className="p-2">Dominant Color</th>
+                  <th className="p-2">Type</th>
+                  <th className="p-2">Size</th>
+                  <th className="p-2">Publish Date/Time</th>
+                  <th className="p-2">Pages</th>
+                  <th className="p-2">Image</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, i) => (
+                  <tr key={i} className="border-t">
+                    <td className="p-2">{row.content}</td>
+                    <td className="p-2">{row.textAmount}</td>
+                    <td className="p-2">{row.style}</td>
+                    <td className="p-2">{row.dominantColor}</td>
+                    <td className="p-2">{row.type}</td>
+                    <td className="p-2">{row.size}</td>
+                    <td className="p-2">{row.publishDateTime}</td>
+                    <td className="p-2">
+                      <div className="space-y-1">
+                        {pages.map((p) => (
+                          <div key={p.id} className="text-xs">
+                            <input type="checkbox" className="mr-1" />{p.name}
+                          </div>
+                        ))}
+                        {linkedinPages.map((p) => (
+                          <div key={p.id} className="text-xs">
+                            <input type="checkbox" className="mr-1" />{p.name}
+                          </div>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="p-2 space-y-2">
+                      {row.imageUrl ? (
+                        <div className="space-y-2">
+                          <img
+                            src={row.imageUrl}
+                            alt="generated"
+                            className="w-32 h-32 object-cover rounded"
+                          />
+                          <div className="flex gap-2">
+                            <a
+                              href={row.imageUrl}
+                              download
+                              className="text-sm underline"
+                            >
+                              Download Image
+                            </a>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => generateImage(i)}
+                            >
+                              Regenerate
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <Button size="sm" onClick={() => generateImage(i)}>
+                          Generate Image
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Wrapper>
+    </div>
+  );
+}
+

--- a/servers/nextjs/app/social/page.tsx
+++ b/servers/nextjs/app/social/page.tsx
@@ -307,8 +307,14 @@ export default function SocialPage() {
     <div className="min-h-screen bg-[#E9E8F8]">
       <OverlayLoader show={loading} text="Loading..." />
       <Header />
-      <div className="p-4 text-right">
-        <Link href="/social/calendar" className="text-sm underline">
+      <div className="p-4 flex gap-4 justify-end text-sm">
+        <Link href="/social/import" className="underline">
+          Import Excel
+        </Link>
+        <Link href="/social/photos" className="underline">
+          Saved Photos
+        </Link>
+        <Link href="/social/calendar" className="underline">
           Weekly planner
         </Link>
       </div>

--- a/servers/nextjs/app/social/photos/page.tsx
+++ b/servers/nextjs/app/social/photos/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { useEffect, useState } from "react";
+import Header from "@/app/dashboard/components/Header";
+import Wrapper from "@/components/Wrapper";
+
+export default function PhotosPage() {
+  const [images, setImages] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchImages = async () => {
+      const res = await fetch("/api/v1/social/images");
+      if (res.ok) {
+        const data = await res.json();
+        setImages(data.images || []);
+      }
+    };
+    fetchImages();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-[#E9E8F8]">
+      <Header />
+      <Wrapper className="py-10 max-w-5xl">
+        <h2 className="text-xl font-bold mb-4">Saved Photos</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {images.map((img, i) => (
+            <img key={i} src={img} alt="saved" className="rounded" />
+          ))}
+        </div>
+      </Wrapper>
+    </div>
+  );
+}
+

--- a/servers/nextjs/package-lock.json
+++ b/servers/nextjs/package-lock.json
@@ -52,7 +52,8 @@
         "tailwind-merge": "^2.5.3",
         "tailwind-scrollbar-hide": "^2.0.0",
         "tailwindcss-animate": "^1.0.7",
-        "tiptap-markdown": "^0.8.10"
+        "tiptap-markdown": "^0.8.10",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/animejs": "^3.1.12",
@@ -2638,6 +2639,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3219,6 +3229,19 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3437,6 +3460,15 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3543,6 +3575,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/crelt": {
@@ -4333,6 +4377,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -6851,6 +6904,18 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -7625,6 +7690,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -7685,6 +7768,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/y18n": {

--- a/servers/nextjs/package.json
+++ b/servers/nextjs/package.json
@@ -55,7 +55,8 @@
     "tailwind-merge": "^2.5.3",
     "tailwind-scrollbar-hide": "^2.0.0",
     "tailwindcss-animate": "^1.0.7",
-    "tiptap-markdown": "^0.8.10"
+    "tiptap-markdown": "^0.8.10",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/animejs": "^3.1.12",


### PR DESCRIPTION
## Summary
- allow uploading Excel files and generating images for each row with social page selection
- add gallery to browse saved images
- link new pages from social tools and add xlsx dependency

## Testing
- `npm install xlsx@^0.18.5`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d90ff0ac832daddecb20bdfc38dc